### PR TITLE
- there's now a command that lets players choose the colour of the XP…

### DIFF
--- a/functions.lua
+++ b/functions.lua
@@ -117,11 +117,9 @@ xp_redo.add_xp = function(playername, xp)
 	if currentRank and currentRank.xp > previousRank.xp then
 		-- level up
 		xp_redo.run_hook("rank_change", { playername, sumXp, currentRank })
-
-		local state = player:get_attribute(xp_redo.HUD_DISPLAY_STATE_NAME)
-		if state and state == "on" then
-			level_up(player, currentRank)
-		end
+		level_up(player, currentRank)
+		local text = "Congratulations, "..playername.." reached "..currentRank.name
+		minetest.chat_send_all(minetest.colorize("#98ff98",text))
 	end
 
 	return sumXp

--- a/init.lua
+++ b/init.lua
@@ -3,11 +3,14 @@ local MP = minetest.get_modpath("xp_redo")
 
 
 xp_redo = {
+	-- rank icon display in HUD
+	disable_hud_icon = minetest.settings:get_bool("xp.display_hud_icon", false),
+
 	-- nametag display (player:set_nametag_attributes)
 	disable_nametag = minetest.settings:get_bool("xp.display_nametag"),
 
 	-- rank entity on top of player
-	disable_hover_entity = minetest.settings:get_bool("xp.disable_hover_entity"),
+	disable_hover_entity = minetest.settings:get_bool("xp.display_hover_entity"),
 
 	-- various different xp rewards per ore
 	enable_dignode_rewards = minetest.settings:get_bool("xp.enable_dignode_rewards"),
@@ -18,9 +21,7 @@ xp_redo = {
 	hud = {
 		posx = tonumber(minetest.settings:get("xp.hud.offsetx") or 0.8),
 		posy = tonumber(minetest.settings:get("xp.hud.offsety") or 0.7)
-	},
-
-	HUD_DISPLAY_STATE_NAME = "hud_state"
+	}
 }
 
 -- optional mapserver-bridge stuff below


### PR DESCRIPTION
… bar and text

- the HUD rank-icon is configurable
- dead players lose not 1000 XP, but only 10% of the next rank
- when a player dies, he is shown how much XP he lost
- players cannot lose levels when they die, only XP
- there's a servermessage now on levelup
- the hud now shows the XP to the next level and the XP a player is already in on that level. Also the XP sum in []

Solves https://github.com/mt-mods/xp_redo/issues/29
Helps https://github.com/mt-mods/xp_redo/issues/44