### PR TITLE
Optional QoS support

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -11,5 +11,6 @@ read_globals = {
 	-- Deps
 	"default", "mesecon", "hb",
 	"screwdriver", "areas", "protector",
-	"woodcutting"
+	"woodcutting",
+	"QoS",
 }

--- a/init.lua
+++ b/init.lua
@@ -27,7 +27,7 @@ xp_redo = {
 }
 
 -- optional mapserver-bridge stuff below
-local http = minetest.request_http_api()
+local http = QoS and QoS(minetest.request_http_api(), 2) or minetest.request_http_api()
 
 dofile(MP.."/utils.lua")
 dofile(MP.."/hooks.lua")

--- a/mod.conf
+++ b/mod.conf
@@ -1,3 +1,3 @@
 name = xp_redo
 depends = default
-optional_depends = protector,doors,mobs_redo,mobs_animal,mobs_monster,mesecons_mvps,hudbars,screwdriver,woodcutting
+optional_depends = qos,protector,doors,mobs_redo,mobs_animal,mobs_monster,mesecons_mvps,hudbars,screwdriver,woodcutting


### PR DESCRIPTION
For less critical reporting/automation use normal priority 2, it does not matter that much if requests get delayed a bit when under extreme load.